### PR TITLE
Fixed #7 by adding migration to correct the harvests for deleted items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # TEvo Harvester Changelog
 
+## 1.1.1 (January 11, 2015)
+- Fixed #7 by adding migration to correct the harvests for deleted items where the `library_method`  was not using the right method. This has been broken since 1.0.0.
+- Removed erroneous comment in `DashboardController`
+
 ## 1.1 (January 5, 2015)
 - Upgrade to Laravel 5.2
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -5,17 +5,6 @@ use TevoHarvester\Tevo\Harvest;
 class DashboardController extends Controller
 {
 
-    /*
-    |--------------------------------------------------------------------------
-    | Welcome Controller
-    |--------------------------------------------------------------------------
-    |
-    | This controller renders the "marketing page" for the application and
-    | is configured to only allow guests. Like most of the other sample
-    | controllers, you are free to modify or remove it as you desire.
-    |
-    */
-
     /**
      * Create a new controller instance.
      *

--- a/database/migrations/2016_01_12_000331_fix_harvests_for_deleted.php
+++ b/database/migrations/2016_01_12_000331_fix_harvests_for_deleted.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class FixHarvestsForDeleted extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("UPDATE harvests SET library_method = 'listCategoriesDeleted', last_run_at = '2010-01-01' WHERE resource = 'categories' AND action = 'deleted';");
+        DB::statement("UPDATE harvests SET library_method = 'listEventsDeleted', last_run_at = '2010-01-01' WHERE resource = 'events' AND action = 'deleted';");
+        DB::statement("UPDATE harvests SET library_method = 'listPerformersDeleted', last_run_at = '2010-01-01' WHERE resource = 'performers' AND action = 'deleted';");
+        DB::statement("UPDATE harvests SET library_method = 'listVenuesDeleted', last_run_at = '2010-01-01' WHERE resource = 'venues' AND action = 'deleted';");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement("UPDATE harvests SET library_method = 'listCategories', last_run_at = '2010-01-01' WHERE resource = 'categories' AND action = 'deleted';");
+        DB::statement("UPDATE harvests SET library_method = 'listEvents', last_run_at = '2010-01-01' WHERE resource = 'events' AND action = 'deleted';");
+        DB::statement("UPDATE harvests SET library_method = 'listPerformers', last_run_at = '2010-01-01' WHERE resource = 'performers' AND action = 'deleted';");
+        DB::statement("UPDATE harvests SET library_method = 'listVenues', last_run_at = '2010-01-01' WHERE resource = 'venues' AND action = 'deleted';");
+    }
+}


### PR DESCRIPTION
Fixed #7 by adding migration to correct the harvests for deleted items where the `library_method`  was not using the right method. This has been broken since 1.0.0.