### PR TITLE
Undefined variable: $category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # TEvo Harvester Changelog
 
+## 2.0.1 (September 20, 2017)
+- Fixes error `StoresFromApi::deleteFromApi()` thanks to (@ujash for the pull request)
+
 ## 2.0.0 (May 24, 2017)
 - [BC Break] New migrations and table schemas
 - Rewrite much of the saving logic

--- a/app/Tevo/StoresFromApi.php
+++ b/app/Tevo/StoresFromApi.php
@@ -70,7 +70,7 @@ trait StoresFromApi
             $item->saveThenDelete();
 
             // Fire an event that it was deleted
-            EventFacade::fire(new ItemWasDeleted($category));
+            EventFacade::fire(new ItemWasDeleted($item));
         }
 
         return $item;


### PR DESCRIPTION
We need to use a $item instead of $category because it returns an error (Undefined variable) on $category variable.