### PR TITLE
Allow non-unique slugs

### DIFF
--- a/database/migrations/2021_12_06_182302_create_tevo_harvest_tables.php
+++ b/database/migrations/2021_12_06_182302_create_tevo_harvest_tables.php
@@ -14,92 +14,94 @@ class CreateTevoHarvestTables extends Migration
      */
     public function up()
     {
-//        Schema::create('brokerages', function (Blueprint $table) {
-//            $table->engine = 'MyISAM';
-//
-//            $table->id();
-//            $table->string('name', 100);
-//            $table->string('abbreviation', 100);
-//            $table->boolean('natb_member')->unsigned()->default(0);
-//            $table->text('logo')->nullable()->default(null);
-//
-//            $table->string('url', 150);
-//            $table->timestamp('tevo_created_at')->nullable()->default(null);
-//            $table->timestamp('tevo_updated_at')->nullable()->default(null);
-//            $table->timestamp('tevo_deleted_at')->nullable()->default(null);
-//            $table->timestamps();
-//            $table->softDeletes();
-//        });
-//        DB::statement('ALTER TABLE brokerages ADD FULLTEXT search(name, abbreviation)');
-//
-//
-//        Schema::create('offices', function (Blueprint $table) {
-//            $table->engine = 'MyISAM';
-//
-//            $table->id();
-//            $table->bigInteger('brokerage_id', false, true)->index();
-//            $table->foreign('brokerage_id')->references('id')->on('brokerages');
-//
-//            $table->string('name', 50);
-//            $table->boolean('main')->unsigned()->default(0);
-//
-//            $table->string('street_address', 100)->nullable()->default(null);
-//            $table->string('extended_address', 100)->nullable()->default(null);
-//            $table->string('locality', 50)->nullable()->default(null);
-//            $table->string('region', 50)->nullable()->default(null)->index();
-//            $table->string('postal_code', 20)->nullable()->default(null);
-//            $table->string('country_code', 2)->nullable()->default(null)->index();
-//            $table->decimal('latitude', 17, 14)->nullable()->default(null);
-//            $table->decimal('longitude', 17, 14)->nullable()->default(null);
-//
-//            $table->string('phone', 20)->nullable()->default(null);
-//            $table->string('fax', 20)->nullable()->default(null);
-//
-//            $table->boolean('po_box')->unsigned()->default(0);
-//            $table->string('time_zone', 30)->nullable()->default(null);
-//            $table->boolean('pos')->unsigned()->default(0);
-//            $table->boolean('evopay')->unsigned()->default(0);
-//            $table->decimal('evopay_discount', 4, 2)->unsigned()->default(0.00);
-//
-//            $table->string('url');
-//            $table->timestamp('fedex_pickup_dropoff_time')->nullable()->default(null);
-//            $table->timestamp('tevo_created_at')->nullable()->default(null);
-//            $table->timestamp('tevo_updated_at')->nullable()->default(null);
-//            $table->timestamp('tevo_deleted_at')->nullable()->default(null);
-//            $table->timestamps();
-//            $table->softDeletes();
-//        });
-//
-//
-//        Schema::create('office_email_addresses', function (Blueprint $table) {
-//            $table->engine = 'MyISAM';
-//
-//            $table->id();
-//            $table->bigInteger('office_id', false, true)->index();
-//            $table->foreign('office_id')->references('id')->on('offices');
-//
-//            $table->string('email_address');
-//
-//            $table->timestamps();
-//            $table->softDeletes();
-//        });
-//
-//
-//        Schema::create('office_hours', function (Blueprint $table) {
-//            $table->engine = 'MyISAM';
-//
-//            $table->id();
-//            $table->bigInteger('office_id', false, true)->index();
-//            $table->foreign('office_id')->references('id')->on('offices');
-//
-//            $table->tinyInteger('day_of_week');
-//            $table->boolean('closed')->unsigned()->default(0);
-//            $table->time('open');
-//            $table->time('close');
-//
-//            $table->timestamps();
-//            $table->softDeletes();
-//        });
+        if (env('CREATE_BROKERAGES_OFFICES', false)) {
+            Schema::create('brokerages', function (Blueprint $table) {
+                $table->engine = 'MyISAM';
+
+                $table->id();
+                $table->string('name', 100);
+                $table->string('abbreviation', 100);
+                $table->boolean('natb_member')->unsigned()->default(0);
+                $table->text('logo')->nullable()->default(null);
+
+                $table->string('url', 150);
+                $table->timestamp('tevo_created_at')->nullable()->default(null);
+                $table->timestamp('tevo_updated_at')->nullable()->default(null);
+                $table->timestamp('tevo_deleted_at')->nullable()->default(null);
+                $table->timestamps();
+                $table->softDeletes();
+            });
+            DB::statement('ALTER TABLE brokerages ADD FULLTEXT search(name, abbreviation)');
+
+
+            Schema::create('offices', function (Blueprint $table) {
+                $table->engine = 'MyISAM';
+
+                $table->id();
+                $table->bigInteger('brokerage_id', false, true)->index();
+                $table->foreign('brokerage_id')->references('id')->on('brokerages');
+
+                $table->string('name', 50);
+                $table->boolean('main')->unsigned()->default(0);
+
+                $table->string('street_address', 100)->nullable()->default(null);
+                $table->string('extended_address', 100)->nullable()->default(null);
+                $table->string('locality', 50)->nullable()->default(null);
+                $table->string('region', 50)->nullable()->default(null)->index();
+                $table->string('postal_code', 20)->nullable()->default(null);
+                $table->string('country_code', 2)->nullable()->default(null)->index();
+                $table->decimal('latitude', 17, 14)->nullable()->default(null);
+                $table->decimal('longitude', 17, 14)->nullable()->default(null);
+
+                $table->string('phone', 20)->nullable()->default(null);
+                $table->string('fax', 20)->nullable()->default(null);
+
+                $table->boolean('po_box')->unsigned()->default(0);
+                $table->string('time_zone', 30)->nullable()->default(null);
+                $table->boolean('pos')->unsigned()->default(0);
+                $table->boolean('evopay')->unsigned()->default(0);
+                $table->decimal('evopay_discount', 4, 2)->unsigned()->default(0.00);
+
+                $table->string('url');
+                $table->timestamp('fedex_pickup_dropoff_time')->nullable()->default(null);
+                $table->timestamp('tevo_created_at')->nullable()->default(null);
+                $table->timestamp('tevo_updated_at')->nullable()->default(null);
+                $table->timestamp('tevo_deleted_at')->nullable()->default(null);
+                $table->timestamps();
+                $table->softDeletes();
+            });
+
+
+            Schema::create('office_email_addresses', function (Blueprint $table) {
+                $table->engine = 'MyISAM';
+
+                $table->id();
+                $table->bigInteger('office_id', false, true)->index();
+                $table->foreign('office_id')->references('id')->on('offices');
+
+                $table->string('email_address');
+
+                $table->timestamps();
+                $table->softDeletes();
+            });
+
+
+            Schema::create('office_hours', function (Blueprint $table) {
+                $table->engine = 'MyISAM';
+
+                $table->id();
+                $table->bigInteger('office_id', false, true)->index();
+                $table->foreign('office_id')->references('id')->on('offices');
+
+                $table->tinyInteger('day_of_week');
+                $table->boolean('closed')->unsigned()->default(0);
+                $table->time('open');
+                $table->time('close');
+
+                $table->timestamps();
+                $table->softDeletes();
+            });
+        }
 
 
         Schema::create('categories', function (Blueprint $table) {
@@ -160,7 +162,7 @@ class CreateTevoHarvestTables extends Migration
 
             $table->id();
             $table->bigInteger('venue_id', false, true)->index();
-            $table->foreign('venue_id')->references('id') ->on('venues');
+            $table->foreign('venue_id')->references('id')->on('venues');
 
             $table->string('name', 100)->index();
             $table->boolean('primary')->unsigned()->default(0);
@@ -277,19 +279,35 @@ class CreateTevoHarvestTables extends Migration
 
             $table->timestamps();
         });
+        if (env('CREATE_BROKERAGES_OFFICES', false)) {
+            DB::table('harvests')->insert([
+                [
+                    'resource'                   => 'brokerages',
+                    'action'                     => 'active',
+                    'library_method'             => 'listBrokerages',
+                    'model_class'                => \App\Models\Tevo\Brokerage::class,
+                    'scheduler_frequency_method' => 'twiceDaily',
+                    'ping_before_url'            => null,
+                    'then_ping_url'              => null,
+                    'last_run_at'                => null,
+                    'created_at'                 => DB::raw('CURRENT_TIMESTAMP'),
+                    'updated_at'                 => DB::raw('CURRENT_TIMESTAMP'),
+                ],
+                [
+                    'resource'                   => 'offices',
+                    'action'                     => 'active',
+                    'library_method'             => 'listOffices',
+                    'model_class'                => \App\Models\Tevo\Office::class,
+                    'scheduler_frequency_method' => 'twiceDaily',
+                    'ping_before_url'            => null,
+                    'then_ping_url'              => null,
+                    'last_run_at'                => null,
+                    'created_at'                 => DB::raw('CURRENT_TIMESTAMP'),
+                    'updated_at'                 => DB::raw('CURRENT_TIMESTAMP'),
+                ],
+            ]);
+        }
         DB::table('harvests')->insert([
-//            [
-//                'resource'                   => 'brokerages',
-//                'action'                     => 'active',
-//                'library_method'             => 'listBrokerages',
-//                'model_class'                => \App\Models\Tevo\Brokerage::class,
-//                'scheduler_frequency_method' => 'twiceDaily',
-//                'ping_before_url'            => null,
-//                'then_ping_url'              => null,
-//                'last_run_at'                => null,
-//                'created_at'                 => DB::raw('CURRENT_TIMESTAMP'),
-//                'updated_at'                 => DB::raw('CURRENT_TIMESTAMP'),
-//            ],
             [
                 'resource'                   => 'categories',
                 'action'                     => 'active',
@@ -350,18 +368,6 @@ class CreateTevoHarvestTables extends Migration
                 'created_at'                 => DB::raw('CURRENT_TIMESTAMP'),
                 'updated_at'                 => DB::raw('CURRENT_TIMESTAMP'),
             ],
-//            [
-//                'resource'                   => 'offices',
-//                'action'                     => 'active',
-//                'library_method'             => 'listOffices',
-//                'model_class'                => \App\Models\Tevo\Office::class,
-//                'scheduler_frequency_method' => 'twiceDaily',
-//                'ping_before_url'            => null,
-//                'then_ping_url'              => null,
-//                'last_run_at'                => null,
-//                'created_at'                 => DB::raw('CURRENT_TIMESTAMP'),
-//                'updated_at'                 => DB::raw('CURRENT_TIMESTAMP'),
-//            ],
             [
                 'resource'                   => 'performers',
                 'action'                     => 'active',

--- a/database/migrations/2021_12_21_180240_change_storage_engine_to_innodb.php
+++ b/database/migrations/2021_12_21_180240_change_storage_engine_to_innodb.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeStorageEngineToInnodb extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement('ALTER TABLE categories ENGINE=InnoDB;');
+        DB::statement('ALTER TABLE configurations ENGINE=InnoDB;');
+        DB::statement('ALTER TABLE events ENGINE=InnoDB;');
+        DB::statement('ALTER TABLE harvests ENGINE=InnoDB;');
+        DB::statement('ALTER TABLE performances ENGINE=InnoDB;');
+        DB::statement('ALTER TABLE performers ENGINE=InnoDB;');
+        DB::statement('ALTER TABLE venues ENGINE=InnoDB;');
+
+        if (env('CREATE_BROKERAGES_OFFICES', false)) {
+            DB::statement('ALTER TABLE brokerages ENGINE=InnoDB;');
+            DB::statement('ALTER TABLE office_email_addresses ENGINE=InnoDB;');
+            DB::statement('ALTER TABLE office_hours ENGINE=InnoDB;');
+            DB::statement('ALTER TABLE offices ENGINE=InnoDB;');
+        }
+    }
+
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement('ALTER TABLE categories ENGINE=MyISAM;');
+        DB::statement('ALTER TABLE configurations ENGINE=MyISAM;');
+        DB::statement('ALTER TABLE events ENGINE=MyISAM;');
+        DB::statement('ALTER TABLE harvests ENGINE=MyISAM;');
+        DB::statement('ALTER TABLE performances ENGINE=MyISAM;');
+        DB::statement('ALTER TABLE performers ENGINE=MyISAM;');
+        DB::statement('ALTER TABLE venues ENGINE=MyISAM;');
+
+        if (env('CREATE_BROKERAGES_OFFICES', false)) {
+            DB::statement('ALTER TABLE brokerages ENGINE=MyISAM;');
+            DB::statement('ALTER TABLE office_email_addresses ENGINE=MyISAM;');
+            DB::statement('ALTER TABLE office_hours ENGINE=MyISAM;');
+            DB::statement('ALTER TABLE offices ENGINE=MyISAM;');
+        }
+    }
+}

--- a/database/migrations/2021_12_21_180245_allow_non_unique_slugs.php
+++ b/database/migrations/2021_12_21_180245_allow_non_unique_slugs.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Some Performers were found to have been deleted and then re-added with the same slugs.
+ * Use a clever solution to allow these to not break anything due to the uniqueness of the slug.
+ *
+ * Example: One Funny Mother exists with IDs 46429 & 70197 and the slug one-funny-mother
+ * ID 46429 was tevo_deleted_at 2019-08-01 18:25:50
+ *
+ * This removes the unique constraint on the slug column and creates a virtual column slug_unique
+ * that will concat the slug with the tevo_deleted_at column and apply a unique index constraint to slug_unique.
+ * 
+ * ID       SLUG                TEVO_DELETED_AT         SLUG_UNIQUE
+ * 46429    one-funny-mother    2019-08-01 18:25:50     one-funny-mother#2019-08-01 18:25:50
+ * 70197    one-funny-mother    NULL                    one-funny-mother#-
+ */
+class AllowNonUniqueSlugs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropUnique('categories_slug_unique');
+            $table->index(['slug']);
+        });
+        DB::statement('ALTER TABLE categories ADD COLUMN slug_unique varchar (150) GENERATED ALWAYS AS (CONCAT (slug, \'#\', IF (tevo_deleted_at IS NULL, \'-\', tevo_deleted_at))) VIRTUAL;');
+        DB::statement('CREATE UNIQUE INDEX categories_slug_unique ON categories (slug_unique);');
+
+        Schema::table('performers', function (Blueprint $table) {
+            $table->dropUnique('performers_slug_unique');
+            $table->index(['slug']);
+        });
+        DB::statement('ALTER TABLE performers ADD COLUMN slug_unique varchar (200) GENERATED ALWAYS AS (CONCAT (slug, \'#\', IF (tevo_deleted_at IS NULL, \'-\', tevo_deleted_at))) VIRTUAL;');
+        DB::statement('CREATE UNIQUE INDEX performers_slug_unique ON performers (slug_unique);');
+
+        Schema::table('venues', function (Blueprint $table) {
+            $table->dropUnique('venues_slug_unique');
+            $table->index(['slug']);
+        });
+        DB::statement('ALTER TABLE venues ADD COLUMN slug_unique varchar (255) GENERATED ALWAYS AS (CONCAT (slug, \'#\', IF (tevo_deleted_at IS NULL, \'-\', tevo_deleted_at))) VIRTUAL;');
+        DB::statement('CREATE UNIQUE INDEX venues_slug_unique ON venues (slug_unique);');
+    }
+
+
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropUnique('categories_slug_unique');
+            $table->dropColumn(['slug_unique']);
+            $table->unique(['slug']);
+        });
+
+        Schema::table('performers', function (Blueprint $table) {
+            $table->dropUnique('performers_slug_unique');
+            $table->dropColumn(['slug_unique']);
+            $table->unique(['slug']);
+        });
+
+        Schema::table('venues', function (Blueprint $table) {
+            $table->dropUnique('venues_slug_unique');
+            $table->dropColumn(['slug_unique']);
+            $table->unique(['slug']);
+        });
+    }
+}


### PR DESCRIPTION
> **NOTE:** This PR also changes the storage engine for all tables from MyISAM to InnoDB 

Some Performers were found to have been deleted and then re-added with the same slugs.
 Use a clever solution to allow these to not break anything due to the uniqueness of the slug.
 
Example: `One Funny Mother` exists with IDs `46429` & `70197` and the slug `one-funny-mother`
ID `46429` was `tevo_deleted_at` `2019-08-01 18:25:50`

This removes the unique constraint on the slug column and creates a virtual column `slug_unique` that will concat the slug with the `tevo_deleted_at` column and apply a unique index constraint to `slug_unique`.
 
 | ID | SLUG | TEVO_DELETED_AT | SLUG_UNIQUE |
| --- | --- | --- | --- |
| 46429 | one-funny-mother | 2019-08-01 18:25:50 | one-funny-mother#2019-08-01 18:25:50 |
| 70197 | one-funny-mother | NULL | one-funny-mother#-|
